### PR TITLE
Make ESP directory name configurable (#1292336)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -315,6 +315,16 @@ AC_SUBST(grubdirname)
 AC_DEFINE_UNQUOTED(GRUB_DIR_NAME, "$grubdirname",
     [Default grub directory name])
 
+AC_ARG_WITH([espdir],
+            AS_HELP_STRING([--with-espdir=DIR],
+                           [set the name of ESP directory [[guessed]]]),
+			   [espdirname="$with_espdir"],
+			   [espdirname="$PACKAGE"])
+
+AC_SUBST(espdirname)
+AC_DEFINE_UNQUOTED(ESP_DIR_NAME, "$espdirname",
+    [Default ESP directory name])
+
 #
 # Checks for build programs.
 #

--- a/util/grub-setpassword.in
+++ b/util/grub-setpassword.in
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 if [ -d /sys/firmware/efi/efivars/ ]; then
-    grubdir=`echo "/@bootdirname@/efi/EFI/redhat/" | sed 's,//*,/,g'`
+    grubdir=`echo "/@bootdirname@/efi/EFI/@espdirname@/" | sed 's,//*,/,g'`
 else
     grubdir=`echo "/@bootdirname@/@grubdirname@" | sed 's,//*,/,g'`
 fi


### PR DESCRIPTION
Replaced the hard coded ESP directory name in the grub setpassword tool
with an option that may be configured at build time.

Resolves: rhbz#1292336
