### PR TITLE
disable cursor during screen update (#1248448)

### DIFF
--- a/grub-core/normal/menu_entry.c
+++ b/grub-core/normal/menu_entry.c
@@ -250,6 +250,8 @@ update_screen (struct screen *screen, struct per_term_screen *term_screen,
       mode = ALL_LINES;
     }
 
+  grub_term_setcursor (term_screen->term, 0);
+
   if (mode != NO_LINE)
     {
       /* Draw lines. This code is tricky, because this must calculate logical
@@ -356,6 +358,8 @@ update_screen (struct screen *screen, struct per_term_screen *term_screen,
 			      y + term_screen->geo.first_entry_y });
 
     }
+
+  grub_term_setcursor (term_screen->term, 1);
 
   grub_term_refresh (term_screen->term);
 }


### PR DESCRIPTION
menu_entry: Disable cursor during update_screen()

When running grub in a VGA console of a KVM pseries guest on PowerPC,
you can see the cursor sweeping over the whole line when entering a
character in editor mode. This is visible because grub always refreshes
the whole line when entering a character in editor mode, and drawing
characters is quite a slow operation with the firmware used for the
powerpc pseries guests (SLOF).
To avoid this ugliness, the cursor should be disabled when refreshing
the screen contents during update_screen().

Signed-off-by: Thomas Huth thuth@redhat.com

Resolves: rhbz#1248448
