### PR TITLE
Treat 'prefix' like the correct variable type

### DIFF
--- a/util/grub.d/00_header.in
+++ b/util/grub.d/00_header.in
@@ -45,7 +45,7 @@ if [ "x${GRUB_TIMEOUT_BUTTON}" = "x" ] ; then GRUB_TIMEOUT_BUTTON="$GRUB_TIMEOUT
 cat << EOF
 set pager=1
 
-if [ -s \$prefix/grubenv ]; then
+if [ -s "${prefix}/grubenv" ]; then
   load_env
 fi
 EOF
@@ -195,7 +195,7 @@ EOF
 # Gettext variables and module
 if [ "x${LANG}" != "xC" ] &&  [ "x${LANG}" != "x" ]; then
   cat << EOF
-  set locale_dir=\$prefix/locale
+  set locale_dir="${prefix}/locale"
   set lang=${grub_lang}
   insmod gettext
 EOF

--- a/util/grub.d/41_custom.in
+++ b/util/grub.d/41_custom.in
@@ -2,8 +2,8 @@
 cat <<EOF
 if [ -f  \${config_directory}/custom.cfg ]; then
   source \${config_directory}/custom.cfg
-elif [ -z "\${config_directory}" -a -f  \$prefix/custom.cfg ]; then
-  source \$prefix/custom.cfg;
+elif [ -z "\${config_directory}" -a -f  "${prefix}/custom.cfg" ]; then
+  source "${prefix}/custom.cfg";
 fi
 EOF
 


### PR DESCRIPTION
The standard input files for grub2-mkconfig contain a variable 'prefix'
that gets set during compilation. The variable is then used by
grub2-mkconfig to populate several files in the configuration file.

The shell script references it as if it should still be a variable in
the finished product. This leads to grub mistakenly thinking that
'prefix' exists in the grub environment when it is actually a shell
variable set in 00_header.

Fixed the files containing references to 'prefix' to treat it like a
shell variable to be interpolated during the grub2-mkconfig run as
opposed to a grub environment variable.